### PR TITLE
add sepolia config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Configured Networks:
 
 - Localhost
 - Goerli. Faucet: https://goerlifaucet.com/
+- Sepolia. Faucet: https://sepoliafaucet.com/
 - BSC Testnet. Faucet: https://testnet.bnbchain.org/faucet-smart
 - BSC.
 - Mordor. Faucet: https://easy.hebeswap.com/#/faucet

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -51,9 +51,14 @@ module.exports = {
       gasPrice: 0,
     },
     goerli: {
-      url: `https://rpc.sepolia.dev/${ALCHEMY_API_KEY}`,
+      url: `https://eth-goerli.alchemyapi.io/v2/${ALCHEMY_API_KEY}`,
       chainId: 5,
-      accounts: [process.env.SEPLOIA_PRIVATE_KEY],
+      accounts: [process.env.GOERLI_PRIVATE_KEY],
+    },
+    sepolia: {
+      url: `https://rpc.sepolia.org`,
+      chainId: 11155111,
+      accounts: [process.env.SEPOLIA_PRIVATE_KEY],
     },
     mordor: {
       url: 'https://www.ethercluster.com/mordor',


### PR DESCRIPTION
Added to hardhat config sepolia network details
Updated readme with url to sepolia faucet

# Quickstart
- Add `SEPOLIA_PRIVATE_KEY` to .env
- Run `npx hardhat --network sepolia deploy --contract Treasury --arg 0x7169D38820dfd117C3FA1f22a697dBA58d90BA06`
